### PR TITLE
adding getZoneDayReport to fetch historic zone readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ tado.getZones(home_id);
 tado.getZoneState(home_id, zone_id);
 tado.getZoneCapabilities(home_id, zone_id);
 tado.getZoneOverlay(home_id, zone_id);
+tado.getZoneDayReport(home_id, zone_id, reportDate)
 tado.getTimeTables(home_id, zone_id);
 tado.getAwayConfiguration(home_id, zone_id);
 tado.getTimeTable(home_id, zone_id, timetable_id);

--- a/index.js
+++ b/index.js
@@ -146,6 +146,10 @@ class Tado {
         return this.apiCall(`/api/v2/homes/${home_id}/zones/${zone_id}/overlay`);
     }
 
+    getZoneDayReport(home_id, zone_id, reportDate) {
+        return this.apiCall(`/api/v2/homes/${home_id}/zones/${zone_id}/dayReport?date=${reportDate}`);
+    }
+
     getTimeTables(home_id, zone_id) {
         return this.apiCall(`/api/v2/homes/${home_id}/zones/${zone_id}/schedule/activeTimetable`);
     }


### PR DESCRIPTION
Hi there,

I've read in the comments of this [article](http://blog.scphillips.com/posts/2017/01/the-tado-api-v2/), that historic zone readings (temperature, humidity, weather, etc.) for a whole day could be requested. So fetching of data from ~midnight to now or any complete day in the past could be easily done.

I'm working on the PR for the node-red module, ... PR follows soon.

Cheers,
Markus