### PR TITLE
Add next_time_block parameter option to setZoneOverlay function

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The ```setZoneOverlay``` method call takes the following arguments
 
 * *power* - **on** or **off** (case insensitive) [**default:** off]
 * *temperature* - *Integer* temperature in Celsius
-* *termination* - *Integer* , **auto**, or **manual** (case insensitive, integer denotes a timer in seconds) [**default:** manual]
+* *termination* - *Integer* , **auto**, **next_time_block**, or **manual** (case insensitive, integer denotes a timer in seconds) [**default:** manual]
 
 The ```setPresence``` method call takes the following arguments
 

--- a/index.js
+++ b/index.js
@@ -195,6 +195,9 @@ class Tado {
             config.termination.durationInSeconds = termination;
         } else if(termination && termination.toLowerCase() == 'auto') {
             config.termination.type = 'TADO_MODE';
+        } else if(termination && termination.toLowerCase() == 'next_time_block') {
+            config.type = 'MANUAL';
+            config.termination.typeSkillBasedApp = 'NEXT_TIME_BLOCK';
         } else {
             config.termination.type = 'MANUAL';
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -515,6 +515,22 @@ describe('High-level API tests', () => {
             .catch(err => {});
     });
 
+    it('Should set a zone\'s overlay to On until next time block ', (done) => {
+        nock('https://my.tado.com')
+            .put('/api/v2/homes/1907/zones/1/overlay')
+            .reply(200, (uri, req) => {
+                return req;
+            });
+
+        tado.setZoneOverlay(1907, 1, 'on', 20, 'next_time_block')
+            .then(response => {
+                expect(typeof response).to.equal('object');
+
+                done();
+            })
+            .catch(err => {});
+    });
+
     it('Should set a device\'s temperature offset', (done) => {
         nock('https://my.tado.com')
             .put('/api/v2/devices/RU04932458/temperatureOffset')


### PR DESCRIPTION
Hi Matt, thanks you for writing this module, I'm really enjoying using it. I have added the tado web api feature which sets a zone overlay until the next block in the smart schedule. It doesn't break any compatibility, I've added a test and readme documentation as well.