### PR TITLE
fix updatePresence()

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,8 @@ class Tado {
     }
 
     async updatePresence(home_id) {
-        const isPresenceAtHome = await this.getState(home_id).presence === 'HOME';
+        let isPresenceAtHome = await this.getState(home_id);
+	    isPresenceAtHome = isPresenceAtHome.presence === 'HOME';
         const isAnyoneAtHome = await this.isAnyoneAtHome(home_id);
 
         if (isAnyoneAtHome !== isPresenceAtHome) {


### PR DESCRIPTION
Fix updatePresence() since await returns a promise first that doesn't come with the later resolved object's properties.
isPresenceAtHome was always evaluated to false due to that bug.