### PR TITLE
Fix isAnyoneAtHome() and updatePresence()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tado.login('username', 'password').then((token) => {
     tado.getMe().then(resp => {
         console.log(resp);
     });
-};
+});
 
 // Get the User's information
 ```

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ class Tado {
         const devices = await this.getMobileDevices(home_id);
 
         for (const device of devices) {
-            if (device.settings.geoTrackingEnabled && device.location.atHome) {
+            if (device.settings.geoTrackingEnabled && device.location && device.location.atHome) {
                 return true;
             }
         }

--- a/index.js
+++ b/index.js
@@ -246,8 +246,9 @@ class Tado {
     }
 
     async updatePresence(home_id) {
-        const isPresenceAtHome = await this.getState(home_id).presence === 'HOME';
         const isAnyoneAtHome = await this.isAnyoneAtHome(home_id);
+        let isPresenceAtHome = await this.getState(home_id);
+        isPresenceAtHome = isPresenceAtHome.presence === 'HOME';
 
         if (isAnyoneAtHome !== isPresenceAtHome) {
             return this.setPresence(home_id, isAnyoneAtHome ? 'HOME' : 'AWAY');


### PR DESCRIPTION
**isAnyoneAtHome():**

The output of one of my devices (via getMobileDevices()) looks like this:
```javascript
[
  {
    name: 'A Device',
    id: 123456,
    settings: {
      geoTrackingEnabled: true,
      onDemandLogRetrievalEnabled: false,
      pushNotifications: [Object]
    },
    location: null,
    deviceMetadata: {
      platform: 'Android',
      osVersion: '10',
      model: 'Vendor model',
      locale: 'de'
    }
  }
]
```

So when I run isAnyoneAtHome(), I get following error:
```
(node:16629) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'atHome' of null
    at Tado.isAnyoneAtHome (node-tado-client/index.js:240:71)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:16629) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:16629) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

The fix is very simple. I first wanted to use optional chaining, but node 12 doesn't support it.


**updatePresence():**

Pretty much identical to #14.


**README.md:**

A closing bracket was missing in the README.md. Not anymore :)