### PR TITLE
Feature/stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ tado.setPresence(home_id, presence);
 tado.updatePresence(home_id);
 tado.setWindowDetection(home_id, zone_id, enabled, timeout);
 tado.getAirComfort(home_id);
+
+/**********************/
+/* EnergyIQ & Savings methods */
+/**********************/
+tado.getEnergyIQ(home_id);
+tado.getEnergyIQtariff(home_id)
+tado.updateEnergyIQtariff(home_id, unit, tariffInCents)
+tado.getEnergyIQMeterReadings(home_id)
+tado.addEnergyIQMeterReading(home_id, date, reading);
+tado.deleteEnergyIQMeterReading(home_id, reading_id)
+tado.getEnergySavingsReport(home_id);
 ```
 
 The ```setZoneOverlay``` method call takes the following arguments

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ This call will return something similar to the following Javascript object.
 ```
 
 The following API calls are available
+
 ```javascript
 /*********************/
 /* Low-level methods */
 /*********************/
 tado.login(username, password);
-tado.apiCall(url, method='get', data={});
+tado.apiCall(url, method = 'get', data = {});
 
 /**********************/
 /* High-level methods */
@@ -112,12 +113,12 @@ tado.getAirComfort(home_id);
 /* EnergyIQ & Savings methods */
 /**********************/
 tado.getEnergyIQ(home_id);
-tado.getEnergyIQtariff(home_id)
-tado.updateEnergyIQtariff(home_id, unit, tariffInCents)
+tado.getEnergyIQTariff(home_id)
+tado.updateEnergyIQTariff(home_id, unit, tariffInCents)
 tado.getEnergyIQMeterReadings(home_id)
 tado.addEnergyIQMeterReading(home_id, date, reading);
 tado.deleteEnergyIQMeterReading(home_id, reading_id)
-tado.getEnergySavingsReport(home_id);
+tado.getEnergySavingsReport(home_id, year, month, countryCode); // countryCode should match home country, it can be retrieved from getHome(home_id).address.country
 ```
 
 The ```setZoneOverlay``` method call takes the following arguments

--- a/index.js
+++ b/index.js
@@ -339,6 +339,13 @@ class Tado {
     async deleteEnergyIQMeterReading(home_id, reading_id){
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/meterReadings/${reading_id}`, 'delete',{});
     }
+
+    // const home = await this.getHome(home_id);
+    //  const country = home.address.country;
+
+    async getEnergySavingsReport(home_id, year, month, countryCode ) {
+        return this.apiCall(`https://energy-bob.tado.com/${home_id}/${year}-${month}?country=${countryCode}`);
+    }
 }
 
 module.exports = Tado;

--- a/index.js
+++ b/index.js
@@ -320,6 +320,13 @@ class Tado {
     async getEnergyIQtariff(home_id) {
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/tariff`);
     }
+
+    async updateEnergyIQtariff(home_id, unit, tariffInCents){
+        if (!['m3', 'kWh'].includes(unit)) {
+            throw new Error(`Invalid unit "${unit}" must be "m3", or "kWh"`);
+        }
+        return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/tariff`, 'put',{ unit: unit, tariffInCents: tariffInCents});
+    }
 }
 
 module.exports = Tado;

--- a/index.js
+++ b/index.js
@@ -317,11 +317,11 @@ class Tado {
     async getEnergyIQ(home_id) {
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/consumption`);
     }
-    async getEnergyIQtariff(home_id) {
+    async getEnergyIQTariff(home_id) {
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/tariff`);
     }
 
-    async updateEnergyIQtariff(home_id, unit, tariffInCents){
+    async updateEnergyIQTariff(home_id, unit, tariffInCents){
         if (!['m3', 'kWh'].includes(unit)) {
             throw new Error(`Invalid unit "${unit}" must be "m3", or "kWh"`);
         }
@@ -341,7 +341,7 @@ class Tado {
     }
 
     // const home = await this.getHome(home_id);
-    //  const country = home.address.country;
+    // const country = home.address.country;
 
     async getEnergySavingsReport(home_id, year, month, countryCode ) {
         return this.apiCall(`https://energy-bob.tado.com/${home_id}/${year}-${month}?country=${countryCode}`);

--- a/index.js
+++ b/index.js
@@ -327,6 +327,10 @@ class Tado {
         }
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/tariff`, 'put',{ unit: unit, tariffInCents: tariffInCents});
     }
+
+    async getEnergyIQMeterReaadings(home_id) {
+        return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/meterReadings`);
+    }
 }
 
 module.exports = Tado;

--- a/index.js
+++ b/index.js
@@ -317,6 +317,9 @@ class Tado {
     async getEnergyIQ(home_id) {
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/consumption`);
     }
+    async getEnergyIQtariff(home_id) {
+        return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/tariff`);
+    }
 }
 
 module.exports = Tado;

--- a/index.js
+++ b/index.js
@@ -69,14 +69,22 @@ class Tado {
     async apiCall(url, method = 'get', data = {}) {
         await this._refreshToken();
 
-        const response = await axios({
-            url: tado_url + url,
+        let callUrl = tado_url + url;
+        if(url.includes('https')){
+            callUrl = url;
+        }
+        let request = {
+            url: callUrl,
             method: method,
             data: data,
             headers: {
                 Authorization: 'Bearer ' + this._accessToken.token.access_token
             }
-        });
+        }
+        if(method === 'get'){
+            delete request.data;
+        }
+        const response = await axios(request);
 
         return response.data;
     }
@@ -304,6 +312,10 @@ class Tado {
         const login = `username=${this._username}&password=${this._password}`;
         const resp = await axios(`https://acme.tado.com/v1/homes/${home_id}/airComfort?${location}&${login}`);
         return resp.data;
+    }
+
+    async getEnergyIQ(home_id) {
+        return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/consumption`);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -328,8 +328,16 @@ class Tado {
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/tariff`, 'put',{ unit: unit, tariffInCents: tariffInCents});
     }
 
-    async getEnergyIQMeterReaadings(home_id) {
+    async getEnergyIQMeterReadings(home_id) {
         return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/meterReadings`);
+    }
+
+    async addEnergyIQMeterReading(home_id, date, reading){
+        return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/meterReadings`, 'post',{ date: date, reading: reading});
+    }
+
+    async deleteEnergyIQMeterReading(home_id, reading_id){
+        return this.apiCall(`https://energy-insights.tado.com/api/homes/${home_id}/meterReadings/${reading_id}`, 'delete',{});
     }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -579,7 +579,7 @@ describe('High-level API tests', () => {
             });
     });
 
-    it('Should get energyIQ Tarif', (done) => {
+    it('Should get energyIQ Tariff', (done) => {
         nock('https://energy-insights.tado.com')
             .get('/api/homes/1907/tariff')
             .reply(200, eneryIQ_tariff_response);
@@ -596,5 +596,23 @@ describe('High-level API tests', () => {
             });
     });
 
+    it('Should update energyIQ Tariff', (done) => {
+
+        nock('https://energy-insights.tado.com')
+            .put('/api/homes/1907/tariff')
+            .reply(200, (uri, req) => {
+                return req;
+            })
+
+        tado.updateEnergyIQtariff('1907', 'm3',303)
+            .then(response => {
+                expect(typeof response).to.equal('object');
+                done();
+            })
+            .catch(err => {
+                console.log(err);
+                done();
+            });
+    });
 
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,8 @@ const away_configuration_response = require('./response.away');
 const timetable_response = require('./response.timetable');
 const zone_overlay_response = require('./response.zone.overlay');
 const eneryIQ_response = require('./response.eneryIQ');
+const eneryIQ_tariff_response = require('./response.eneryIQ.tariff');
+
 describe('OAuth2 tests', () => {
     it('Should login', (done) => {
         nock('https://auth.tado.com')
@@ -567,6 +569,23 @@ describe('High-level API tests', () => {
 
 
         tado.getEnergyIQ('1907')
+            .then(response => {
+                expect(typeof response).to.equal('object');
+                done();
+            })
+            .catch(err => {
+                console.log(err);
+                done();
+            });
+    });
+
+    it('Should get energyIQ Tarif', (done) => {
+        nock('https://energy-insights.tado.com')
+            .get('/api/homes/1907/tariff')
+            .reply(200, eneryIQ_tariff_response);
+
+
+        tado.getEnergyIQtariff('1907')
             .then(response => {
                 expect(typeof response).to.equal('object');
                 done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,6 +24,7 @@ const zone_overlay_response = require('./response.zone.overlay');
 const eneryIQ_response = require('./response.eneryIQ');
 const eneryIQ_tariff_response = require('./response.eneryIQ.tariff');
 const eneryIQ_meter_readings_response = require('./response.eneryIQ.meterReadings');
+const eneryIQ_savings_response = require('./response.eneryIQ.savings');
 
 describe('OAuth2 tests', () => {
     it('Should login', (done) => {
@@ -649,5 +650,22 @@ describe('High-level API tests', () => {
                 done();
             });
     });
+
+    it('Should get energyIQ savings', (done) => {
+        nock('https://energy-bob.tado.com')
+            .get('/1907/2021-11?country=NLD')
+            .reply(200, eneryIQ_savings_response);
+
+        tado.getEnergySavingsReport('1907', 2021, 11, 'NLD')
+            .then(response => {
+                expect(typeof response).to.equal('object');
+                done();
+            })
+            .catch(err => {
+                console.log(err);
+                done();
+            });
+    });
+
 
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,6 +23,7 @@ const timetable_response = require('./response.timetable');
 const zone_overlay_response = require('./response.zone.overlay');
 const eneryIQ_response = require('./response.eneryIQ');
 const eneryIQ_tariff_response = require('./response.eneryIQ.tariff');
+const eneryIQ_meter_readings_response = require('./response.eneryIQ.meterReadings');
 
 describe('OAuth2 tests', () => {
     it('Should login', (done) => {
@@ -605,6 +606,23 @@ describe('High-level API tests', () => {
             })
 
         tado.updateEnergyIQtariff('1907', 'm3',303)
+            .then(response => {
+                expect(typeof response).to.equal('object');
+                done();
+            })
+            .catch(err => {
+                console.log(err);
+                done();
+            });
+    });
+
+    it('Should get energyIQ meter readings', (done) => {
+        nock('https://energy-insights.tado.com')
+            .get('/api/homes/1907/meterReadings')
+            .reply(200, eneryIQ_meter_readings_response);
+
+
+        tado.getEnergyIQMeterReaadings('1907')
             .then(response => {
                 expect(typeof response).to.equal('object');
                 done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ const timetables_response = require('./response.timetables');
 const away_configuration_response = require('./response.away');
 const timetable_response = require('./response.timetable');
 const zone_overlay_response = require('./response.zone.overlay');
-
+const eneryIQ_response = require('./response.eneryIQ');
 describe('OAuth2 tests', () => {
     it('Should login', (done) => {
         nock('https://auth.tado.com')
@@ -559,4 +559,23 @@ describe('High-level API tests', () => {
             })
             .catch(err => {});
     });
+
+    it('Should get energyIQ', (done) => {
+        nock('https://energy-insights.tado.com')
+            .get('/api/homes/1907/consumption')
+            .reply(200, eneryIQ_response);
+
+
+        tado.getEnergyIQ('1907')
+            .then(response => {
+                expect(typeof response).to.equal('object');
+                done();
+            })
+            .catch(err => {
+                console.log(err);
+                done();
+            });
+    });
+
+
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -587,7 +587,7 @@ describe('High-level API tests', () => {
             .reply(200, eneryIQ_tariff_response);
 
 
-        tado.getEnergyIQtariff('1907')
+        tado.getEnergyIQTariff('1907')
             .then(response => {
                 expect(typeof response).to.equal('object');
                 done();
@@ -606,7 +606,7 @@ describe('High-level API tests', () => {
                 return req;
             })
 
-        tado.updateEnergyIQtariff('1907', 'm3',303)
+        tado.updateEnergyIQTariff('1907', 'm3',303)
             .then(response => {
                 expect(typeof response).to.equal('object');
                 done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -621,8 +621,25 @@ describe('High-level API tests', () => {
             .get('/api/homes/1907/meterReadings')
             .reply(200, eneryIQ_meter_readings_response);
 
+        tado.getEnergyIQMeterReadings('1907')
+            .then(response => {
+                expect(typeof response).to.equal('object');
+                done();
+            })
+            .catch(err => {
+                console.log(err);
+                done();
+            });
+    });
 
-        tado.getEnergyIQMeterReaadings('1907')
+    it('Should add energyIQ meter readings', (done) => {
+        nock('https://energy-insights.tado.com')
+            .post('/api/homes/1907/meterReadings')
+            .reply(200, (uri, req) => {
+                return req;
+            })
+
+        tado.addEnergyIQMeterReading('1907','2022-01-05',6813)
             .then(response => {
                 expect(typeof response).to.equal('object');
                 done();

--- a/test/response.eneryIQ.js
+++ b/test/response.eneryIQ.js
@@ -1,0 +1,27 @@
+module.exports = {
+    "current": {
+        "consumed": {
+            "amount": "5.1 kWh",
+            "kwh": 5.1,
+            "cost": 1.5,
+            "m3": 0.5
+        },
+        "dateRange": {
+            "start": "2022-01-01T00:00:00",
+            "end": "2022-01-03T23:59:59"
+        }
+    },
+    "last": {
+        "consumed": {
+            "amount": "156.2 kWh",
+            "kwh": 156.2,
+            "cost": 43,
+            "m3": 14.2
+        },
+        "dateRange": {
+            "start": "2021-12-01T00:00:00",
+            "end": "2021-12-31T23:59:59"
+        }
+    }
+}
+

--- a/test/response.eneryIQ.meterReadings.js
+++ b/test/response.eneryIQ.meterReadings.js
@@ -1,0 +1,103 @@
+module.exports = {
+    readings: [
+        {
+            id: '123f0f1e-e1d9-474f-b6f6-06446a323947',
+            homeId: 440464,
+            reading: 6812,
+            date: '2022-01-03'
+        },
+        {
+            id: 'b1168492-87a0-4349-b00b-285fef9e107c',
+            homeId: 440464,
+            reading: 6811,
+            date: '2021-12-31'
+        },
+        {
+            id: '62517ec7-239f-4391-9281-af112c14f181',
+            homeId: 440464,
+            reading: 6811,
+            date: '2021-12-29'
+        },
+        {
+            id: 'bbfc221f-fde3-47cc-9689-77aed5bc814b',
+            homeId: 440464,
+            reading: 6810,
+            date: '2021-12-26'
+        },
+        {
+            id: 'bac50421-2117-46d7-b068-b3165c87c605',
+            homeId: 440464,
+            reading: 6808,
+            date: '2021-12-20'
+        },
+        {
+            id: 'ece97b27-09f9-4505-a187-d2d189ad190b',
+            homeId: 440464,
+            reading: 6807,
+            date: '2021-12-17'
+        },
+        {
+            id: '6a6388db-d92c-4a63-b6e7-15f573cd7ace',
+            homeId: 440464,
+            reading: 6806,
+            date: '2021-12-11'
+        },
+        {
+            id: 'f379b544-1bb5-4a57-be5d-35cb43891b6f',
+            homeId: 440464,
+            reading: 6805,
+            date: '2021-12-08'
+        },
+        {
+            id: '06b8f6a5-9812-4bca-975a-b6c80264c8f2',
+            homeId: 440464,
+            reading: 6803,
+            date: '2021-12-05'
+        },
+        {
+            id: '694719f8-d614-40c4-ae03-71158ec226ba',
+            homeId: 440464,
+            reading: 6802,
+            date: '2021-12-04'
+        },
+        {
+            id: 'aa57ad0f-2323-4b7f-821d-7b8034eedced',
+            homeId: 440464,
+            reading: 6800,
+            date: '2021-12-03'
+        },
+        {
+            id: '531294e1-11d5-4235-8686-dc5ad62d0697',
+            homeId: 440464,
+            reading: 6797,
+            date: '2021-12-01'
+        },
+        {
+            id: '7e89067c-6de2-45fa-884e-85e41aee5686',
+            homeId: 440464,
+            reading: 6791,
+            date: '2021-11-26'
+        },
+        {
+            id: '623d3d86-e4d4-4418-8f72-c81d7c83b7a9',
+            homeId: 440464,
+            reading: 6774,
+            date: '2021-10-29'
+        },
+        {
+            id: '593360d8-4e32-4718-8f0d-6b5315d18dc3',
+            homeId: 440464,
+            reading: 6767,
+            date: '2021-10-07'
+        },
+        {
+            id: '5e8133d0-cc2c-4933-8b58-e3eddf95bf3e',
+            homeId: 440464,
+            reading: 6765,
+            date: '2021-09-25'
+        }
+    ]
+}
+
+
+

--- a/test/response.eneryIQ.meterReadings_update.js
+++ b/test/response.eneryIQ.meterReadings_update.js
@@ -1,0 +1,9 @@
+module.exports = {
+    "id": "80075776-7588-4a12-a077-3dd7c2f0c61d",
+    "homeId": 440464,
+    "date": "2022-01-05",
+    "reading": 6813
+}
+
+
+

--- a/test/response.eneryIQ.savings.js
+++ b/test/response.eneryIQ.savings.js
@@ -1,0 +1,71 @@
+module.exports = {
+    "coveredInterval": {
+        "start": "2021-08-31T23:41:23.366000Z",
+        "end": "2021-09-30T06:41:34.688000Z"
+    },
+    "totalSavingsAvailable": true,
+    "withAutoAssist": {
+        "detectedAwayDuration": {
+            "value": 68,
+            "unit": "HOURS"
+        },
+        "openWindowDetectionTimes": 103
+    },
+    "totalSavingsInThermostaticMode": {
+        "value": 678,
+        "unit": "HOURS"
+    },
+    "manualControlSaving": {
+        "value": 85.69999694824219,
+        "unit": "PERCENTAGE"
+    },
+    "totalSavings": {
+        "value": 30.9,
+        "unit": "PERCENTAGE"
+    },
+    "hideSunshineDuration": false,
+    "awayDuration": {
+        "value": 67,
+        "unit": "HOURS"
+    },
+    "showSavingsInThermostaticMode": true,
+    "communityNews": {
+        "type": "HOME_COMFORT_STATES",
+        "states": [{
+            "name": "humid",
+            "value": 97.9,
+            "unit": "PERCENTAGE"
+        }, {
+            "name": "ideal",
+            "value": 1.2,
+            "unit": "PERCENTAGE"
+        }, {
+            "name": "cold",
+            "value": 0.6,
+            "unit": "PERCENTAGE"
+        }, {
+            "name": "warm",
+            "value": 0.3,
+            "unit": "PERCENTAGE"
+        }, {
+            "name": "dry",
+            "value": 0,
+            "unit": "PERCENTAGE"
+        }]
+    },
+    "sunshineDuration": {
+        "value": 49,
+        "unit": "HOURS"
+    },
+    "hasAutoAssist": true,
+    "openWindowDetectionTimes": 1,
+    "setbackScheduleDurationPerDay": {
+        "value": 0,
+        "unit": "HOURS"
+    },
+    "totalSavingsInThermostaticModeAvailable": true,
+    "yearMonth": "2021-09",
+    "hideOpenWindowDetection": false,
+    "home": 440464,
+    "hideCommunityNews": false
+}

--- a/test/response.eneryIQ.tariff.js
+++ b/test/response.eneryIQ.tariff.js
@@ -1,0 +1,3 @@
+module.exports = { unit: 'm3', tariffInCents: 303 }
+
+


### PR DESCRIPTION
Added support for EnergyIQ & savings using the followings new API's

```
GET https://energy-insights.tado.com/api/homes/${home_id}/consumption
GET https://energy-insights.tado.com/api/homes/${home_id}/tariff
PUT https://energy-insights.tado.com/api/homes/${home_id}/tariff
GET https://energy-insights.tado.com/api/homes/${home_id}/meterReadings
POST https://energy-insights.tado.com/api/homes/${home_id}/meterReadings
DELETE https://energy-insights.tado.com/api/homes/${home_id}/meterReadings/${reading_id}
GET https://energy-bob.tado.com/${home_id}/${year}-${month}?country=${countryCode}
```

Created the following highlevel support functions
```
tado.getEnergyIQ(home_id);
tado.getEnergyIQtariff(home_id)
tado.updateEnergyIQtariff(home_id, unit, tariffInCents)
tado.getEnergyIQMeterReadings(home_id)
tado.addEnergyIQMeterReading(home_id, date, reading);
tado.deleteEnergyIQMeterReading(home_id, reading_id)
tado.getEnergySavingsReport(home_id, year, month, country);
```

Updated the tests
```
Should get energyIQ
Should get energyIQ Tariff
Should update energyIQ Tariff
Should get energyIQ meter readings
Should add energyIQ meter readings
Should get energyIQ savings
```

Notes: the getEnergySavingsReport needs the country from the home ,
```
const home = await tado.getHome(home_id) 
const country = home.address.country
```

Since my tado setup only has one home configured(i get a home object) and the unit test indicates that getHome can return a array with homes i decided not to retrieve the home->country in the getEnergySavingsReport method because the home response is unclear-> better to let implementation retrieve the home country code.

