### PR TITLE
Adds HTTPS Agent with keep-alive enabled to Axios requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,13 +19,14 @@ const { ResourceOwnerPassword } = require('simple-oauth2');
 const client = new ResourceOwnerPassword(tado_config);
 
 const axios = require('axios');
-
+const { Agent } = require('https');
 
 class Tado {
     constructor(username, password) {
         this._username = username;
         this._password = password;
         this._accessToken;
+        this._httpsAgent = new Agent({ keepAlive: true });
     }
 
     async _login() {
@@ -79,7 +80,8 @@ class Tado {
             data: data,
             headers: {
                 Authorization: 'Bearer ' + this._accessToken.token.access_token
-            }
+            },
+            httpsAgent: this._httpsAgent
         }
         if(method === 'get'){
             delete request.data;


### PR DESCRIPTION
When performing multiple requests to the Tado API, using a HTTPS Agent with keep alive allows the connection to be re-used for subsequent requests, which offers a speed increase when making multiple calls.

I haven't attempted to integrate with the oauth client, or on the Air Comfort endpoint, mainly because on a quick DNS lookup Taco don't appear to be hosting those in the same environment, so the agent wouldn't re-use the connection anyway.