### PR TITLE
Update index.d.ts

### DIFF
--- a/build/types/index.d.ts
+++ b/build/types/index.d.ts
@@ -300,8 +300,11 @@ export type ZoneControl = {
         uis: Device[];
     };
 };
+type ZoneStatesMapping = {
+    [key: string]: ZoneState;
+}
 export type ZoneStates = {
-    zoneStates: ZoneState[];
+    zoneStates: ZoneStatesMapping;
 };
 export type HeatingCircuit = {
     number: number;


### PR DESCRIPTION
Include property zoneStates in type ZoneStates

So that the return value of getZoneStates of type ZoneStates correctly reflects the API return value for this endpoint as illustrated below.

```javascript
{
  zoneStates: {
    '0': {
      tadoMode: 'HOME',
      geolocationOverride: false
      // bla
    }
  }
}
```