### PR TITLE
fix: ensure mobile device location type represents the possible null value

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,9 +33,11 @@ import {
 // utils
 export type DeepPartial<T> = T extends object
     ? {
-          [P in keyof T]?: DeepPartial<T[P]>
-      }
+        [P in keyof T]?: DeepPartial<T[P]>
+    }
     : T
+
+type Nullable<T> = T | null
 
 // tado
 /** Example: `'en'`  */
@@ -152,7 +154,7 @@ export type MobileDevice = {
     name: string
     id: number
     settings: MobileDeviceSettings
-    location: MobileDeviceLocation
+    location: Nullable<MobileDeviceLocation>
     deviceMetadata: MobileDeviceMetadata
 }
 
@@ -450,17 +452,17 @@ export type ZoneCapabilitiesTemperatures = {
 
 export type ZoneCapabilities =
     | {
-          type: 'HEATING'
-          temperatures: ZoneCapabilitiesTemperatures
-      }
+        type: 'HEATING'
+        temperatures: ZoneCapabilitiesTemperatures
+    }
     | ({
-          type: 'AIR_CONDITIONING'
-      } & {
-          [key in ACMode]: ZoneCapabilitiesAC
-      })
+        type: 'AIR_CONDITIONING'
+    } & {
+            [key in ACMode]: ZoneCapabilitiesAC
+        })
     | {
-          type: 'HOT_WATER'
-      }
+        type: 'HOT_WATER'
+    }
 
 export type AwayConfiguration = {
     type: ZoneType
@@ -675,16 +677,16 @@ export type MeasurePercentage = {
 
 export type MeasureStripeData =
     | {
-          stripeType: StripeTypeValue
-          setting: {
-              type: 'HEATING'
-              power: Power
-              temperature: Temperature | null
-          }
-      }
+        stripeType: StripeTypeValue
+        setting: {
+            type: 'HEATING'
+            power: Power
+            temperature: Temperature | null
+        }
+    }
     | {
-          stripeType: 'AWAY'
-      }
+        stripeType: 'AWAY'
+    }
 
 export type MeasureStripe = {
     timeSeriesType: 'dataIntervals'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,8 +33,8 @@ import {
 // utils
 export type DeepPartial<T> = T extends object
     ? {
-        [P in keyof T]?: DeepPartial<T[P]>
-    }
+          [P in keyof T]?: DeepPartial<T[P]>
+      }
     : T
 
 type Nullable<T> = T | null
@@ -452,17 +452,17 @@ export type ZoneCapabilitiesTemperatures = {
 
 export type ZoneCapabilities =
     | {
-        type: 'HEATING'
-        temperatures: ZoneCapabilitiesTemperatures
-    }
+          type: 'HEATING'
+          temperatures: ZoneCapabilitiesTemperatures
+      }
     | ({
-        type: 'AIR_CONDITIONING'
-    } & {
-            [key in ACMode]: ZoneCapabilitiesAC
-        })
+          type: 'AIR_CONDITIONING'
+      } & {
+          [key in ACMode]: ZoneCapabilitiesAC
+      })
     | {
-        type: 'HOT_WATER'
-    }
+          type: 'HOT_WATER'
+      }
 
 export type AwayConfiguration = {
     type: ZoneType
@@ -677,16 +677,16 @@ export type MeasurePercentage = {
 
 export type MeasureStripeData =
     | {
-        stripeType: StripeTypeValue
-        setting: {
-            type: 'HEATING'
-            power: Power
-            temperature: Temperature | null
-        }
-    }
+          stripeType: StripeTypeValue
+          setting: {
+              type: 'HEATING'
+              power: Power
+              temperature: Temperature | null
+          }
+      }
     | {
-        stripeType: 'AWAY'
-    }
+          stripeType: 'AWAY'
+      }
 
 export type MeasureStripe = {
     timeSeriesType: 'dataIntervals'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,7 +154,7 @@ export type MobileDevice = {
     name: string
     id: number
     settings: MobileDeviceSettings
-    location: Nullable<MobileDeviceLocation>
+    location?: Nullable<MobileDeviceLocation>
     deviceMetadata: MobileDeviceMetadata
 }
 


### PR DESCRIPTION
This PR ensures that the typings represent the possible value of `null` that can be returned from the Tado API for `MobileDevice`s locations.