### PR TITLE
fix: update some zone state properties for which `null` is a valid value

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -366,11 +366,11 @@ export type ZoneState = {
     geolocationOverrideDisableTime: boolean | null
     preparation: any // TODO:
     setting: TimeTableSettings
-    overlayType: 'MANUAL'
-    overlay: ZoneOverlay
-    openWindow: ZoneOpenWindow
-    nextScheduleChange: ZoneStateNextScheduleChange
-    nextTimeBlock: ZoneNextTimeBlock
+    overlayType: Nullable<'MANUAL'>
+    overlay: Nullable<ZoneOverlay>
+    openWindow: Nullable<ZoneOpenWindow>
+    nextScheduleChange: Nullable<ZoneStateNextScheduleChange>
+    nextTimeBlock: Nullable<ZoneNextTimeBlock>
     link: ZoneLink
     activityDataPoints: ZoneActivityDataPoints
     sensorDataPoints: ZoneStateSensorDataPoints


### PR DESCRIPTION
- `nextScheduleChange` and `nextTimeBlock` appear to be able to be `null` when a single temperature value is set for the 24 hour block, effectively a static temperature.
- `overlay` can be `null` and consequently `overlayType` can also be null. It looks like this occurs when there has been no manual override of the normal schedule for a zone.
- `openWindow` can be `null`. I've never seen this have a value but that may be because open window detection triggers very infrequently for me.