### PR TITLE
ci: add a publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,60 @@
+name: Release Package
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Get package version
+        id: get-package-version
+        shell: bash
+        run: |
+          echo "version=$(cat package.json  | jq -r .version)" >> $GITHUB_OUTPUT
+
+      - name: Ensure tag matches package versions
+        shell: bash
+        run: |
+          test "${{ github.ref_name }}" == "v${{ steps.get-package-version.outputs.version }}"
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "${{ github.ref_name }}"
+          generateReleaseNotes: true
+          makeLatest: true
+
+  publish:
+    name: Publish Package
+    runs-on: ubuntu-latest
+    needs: release
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup
+
+      - name: Build distribution
+        shell: bash
+        run: pnpm build
+
+      - name: Publish package
+        run: pnpm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
If this does not match the release wofklow today, please feel free to close. The workflow expects the following release flow.

1. A new version is tagged using `pnpm version` command.
2. The new tag (`v<version>`) and default branch is pushed to remote.
3. The workflow creates a new release on GitHub associated with the tag.
4. The workflow builds the package for publishing.
5. The workflow publishes package to npmjs.

The workflow requires the `NPM_TOKEN` action secret to be set to a valid token. 