### PR TITLE
Added option to the authentication that allows you to pass an existing token to tado

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following API calls are available
 /* Authentication */
 /*********************/
 tado.authenticate(refreshToken?, interval?);
+tado.authenticateWithToken(token?, interval?);
 tado.setTokenCallback(cb);
 
 /*********************/

--- a/examples/auth.ts
+++ b/examples/auth.ts
@@ -18,10 +18,16 @@ async function main(): Promise<void> {
     );
     console.log("------------------------------------------------");
   }
-  await futureToken;
+  const token = await futureToken;
 
   const me = await tado.getMe();
   console.log(me);
+
+  const [_, futureToken2] = await tado.authenticateWithToken(token);
+  const token2 = await futureToken2;
+  console.log("new token: ", token2);
+  const me2 = await tado.getMe();
+  console.log(me2);
 }
 
 main();


### PR DESCRIPTION
Hello,

I created a new function called `authenticateWithToken` that allows you to pass an existing token to the authentication. 
We can use it to re-use the token that Tado provides in the 10 minutes period (as per Tado documentation).

